### PR TITLE
Migrate image generation to OpenAI API (gpt-image) in query handler

### DIFF
--- a/applications/RPGTableHelper.WebApi/Startup.cs
+++ b/applications/RPGTableHelper.WebApi/Startup.cs
@@ -392,11 +392,8 @@ public class Startup
         }
 
         services.AddTransient<INoteService, NoteService>();
-        var openAiOptions = Configuration.GetSection("OpenAi").Get<OpenAIOptions>();
-        if (openAiOptions != null)
-        {
-            services.AddSingleton(openAiOptions);
-        }
+        var openAiOptions = Configuration.GetSection("OpenAi").Get<OpenAIOptions>() ?? new OpenAIOptions();
+        services.AddSingleton(openAiOptions);
 
         var jwtOptions = Configuration.GetSection("Jwt").Get<JwtOptions>();
         if (jwtOptions != null)

--- a/libraries/RPGTableHelper.DataLayer.OpenAI.Contracts/Options/OpenAIOptions.cs
+++ b/libraries/RPGTableHelper.DataLayer.OpenAI.Contracts/Options/OpenAIOptions.cs
@@ -2,8 +2,20 @@ namespace RPGTableHelper.DataLayer.OpenAI.Contracts.Options
 {
     public class OpenAIOptions
     {
+        /// <summary>
+        /// OpenAI API key from https://platform.openai.com (required for image generation).
+        /// </summary>
         public string? ApiKey { get; set; }
 
+        /// <summary>
+        /// Optional override for the OpenAI API base URL (e.g. https://api.openai.com/v1).
+        /// When null or empty, the SDK default is used.
+        /// </summary>
         public string? OpenAIUrl { get; set; }
+
+        /// <summary>
+        /// Model id for <c>images/generations</c> (e.g. gpt-image-1, gpt-image-1-mini). Defaults to gpt-image-1 when unset.
+        /// </summary>
+        public string? ImageModel { get; set; }
     }
 }

--- a/libraries/RPGTableHelper.DataLayer.OpenAI/QueryHandlers/AiGenerateImageQueryHandler.cs
+++ b/libraries/RPGTableHelper.DataLayer.OpenAI/QueryHandlers/AiGenerateImageQueryHandler.cs
@@ -1,8 +1,4 @@
-using System;
 using System.ClientModel;
-
-using Azure;
-using Azure.AI.OpenAI;
 
 using Microsoft.Extensions.Logging;
 
@@ -18,11 +14,17 @@ namespace RPGTableHelper.DataLayer.OpenAI.QueryHandlers;
 
 public class AiGenerateImageQueryHandler : IQueryHandler<AiGenerateImageQuery, Stream>
 {
+    private const string DefaultImageModel = "gpt-image-1";
+
     private readonly IHttpClientFactory _httpClientFactory;
-    private readonly ILogger _logger;
+    private readonly ILogger<AiGenerateImageQueryHandler> _logger;
     private readonly OpenAIOptions _options;
 
-    public AiGenerateImageQueryHandler(OpenAIOptions options, IHttpClientFactory httpClientFactory, ILogger logger)
+    public AiGenerateImageQueryHandler(
+        OpenAIOptions options,
+        IHttpClientFactory httpClientFactory,
+        ILogger<AiGenerateImageQueryHandler> logger
+    )
     {
         _options = options;
         _httpClientFactory = httpClientFactory;
@@ -33,56 +35,71 @@ public class AiGenerateImageQueryHandler : IQueryHandler<AiGenerateImageQuery, S
 
     public async Task<Option<Stream>> RunQueryAsync(AiGenerateImageQuery query, CancellationToken cancellationToken)
     {
-        if (_options.ApiKey == null || _options.OpenAIUrl == null)
+        if (string.IsNullOrWhiteSpace(_options.ApiKey))
         {
             return Option.None;
         }
 
-        var endpoint = _options.OpenAIUrl;
-        var key = _options.ApiKey;
+        var credential = new ApiKeyCredential(_options.ApiKey);
+        OpenAIClient client = string.IsNullOrWhiteSpace(_options.OpenAIUrl)
+            ? new OpenAIClient(credential)
+            : new OpenAIClient(credential, new OpenAIClientOptions { Endpoint = new Uri(_options.OpenAIUrl) });
 
-        var azureClient = new AzureOpenAIClient(new Uri(endpoint), new ApiKeyCredential(key));
-
-        // This must match the custom deployment name you chose for your model
-        ImageClient chatClient = azureClient.GetImageClient("dall-e-3");
+        var model = string.IsNullOrWhiteSpace(_options.ImageModel)
+            ? DefaultImageModel
+            : _options.ImageModel.Trim();
+        var imageClient = client.GetImageClient(model);
 
         try
         {
-            var imageGeneration = await chatClient.GenerateImageAsync(
-                query.ImagePrompt,
-                new ImageGenerationOptions()
-                {
-                    Size = GeneratedImageSize.W1024xH1024,
-                    Style = GeneratedImageStyle.Vivid,
-                    Quality = GeneratedImageQuality.Standard,
-                    ResponseFormat = GeneratedImageFormat.Uri,
-                }
-            );
+            var imageGeneration = await imageClient
+                .GenerateImageAsync(
+                    query.ImagePrompt,
+                    new ImageGenerationOptions()
+                    {
+                        Size = GeneratedImageSize.W1024xH1024,
+                        Quality = GeneratedImageQuality.High,
+                    },
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
 
-            _logger.LogInformation(imageGeneration.Value.ImageUri.ToString());
-            _logger.LogInformation(imageGeneration.Value.RevisedPrompt);
+            var generated = imageGeneration.Value;
 
-            try
+            if (!string.IsNullOrEmpty(generated.RevisedPrompt))
             {
-                using (var client = _httpClientFactory.CreateClient())
-                {
-                    // Get the file content as a stream
-                    Stream stream = await client.GetStreamAsync(imageGeneration.Value.ImageUri);
-                    return stream;
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(exception: ex, message: "An error occured");
+                _logger.LogInformation("{RevisedPrompt}", generated.RevisedPrompt);
             }
 
-            // return imageGeneration.Value.ImageUri.ToString();
+            var imageBytes = generated.ImageBytes;
+            if (imageBytes != null && imageBytes.ToMemory().Length > 0)
+            {
+                var bytes = imageBytes.ToArray();
+                return Option.From<Stream>(new MemoryStream(bytes, writable: false));
+            }
+
+            if (generated.ImageUri != null)
+            {
+                _logger.LogInformation("{ImageUri}", generated.ImageUri);
+                try
+                {
+                    var http = _httpClientFactory.CreateClient();
+                    var stream = await http.GetStreamAsync(generated.ImageUri, cancellationToken).ConfigureAwait(false);
+                    return Option.From(stream);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to download generated image from URL.");
+                    return Option.None;
+                }
+            }
+
+            return Option.None;
         }
-        catch (Exception ex1)
+        catch (Exception ex)
         {
-            _logger.LogError(exception: ex1, message: "An error occured");
+            _logger.LogError(ex, "OpenAI image generation failed.");
+            return Option.None;
         }
-
-        return Option.None;
     }
 }

--- a/tests/RPGTableHelper.DataLayer.Tests/QueryHandlers/OpenAI/AiGenerateImageQueryHandlerTests.cs
+++ b/tests/RPGTableHelper.DataLayer.Tests/QueryHandlers/OpenAI/AiGenerateImageQueryHandlerTests.cs
@@ -1,0 +1,26 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Prodot.Patterns.Cqrs;
+using RPGTableHelper.DataLayer.OpenAI.Contracts.Options;
+using RPGTableHelper.DataLayer.OpenAI.Contracts.Queries;
+using RPGTableHelper.DataLayer.OpenAI.QueryHandlers;
+
+namespace RPGTableHelper.DataLayer.Tests.QueryHandlers.OpenAI;
+
+public class AiGenerateImageQueryHandlerTests
+{
+    [Fact]
+    public async Task RunQueryAsync_WhenApiKeyMissing_ReturnsNone()
+    {
+        var options = new OpenAIOptions { ApiKey = null };
+        var httpFactory = Substitute.For<IHttpClientFactory>();
+        var logger = Substitute.For<ILogger<AiGenerateImageQueryHandler>>();
+        var subjectUnderTest = new AiGenerateImageQueryHandler(options, httpFactory, logger);
+        var query = new AiGenerateImageQuery { ImagePrompt = "a red cube" };
+
+        var result = await subjectUnderTest.RunQueryAsync(query, default);
+
+        result.IsSome.Should().BeFalse();
+    }
+}

--- a/tests/RPGTableHelper.DataLayer.Tests/RPGTableHelper.DataLayer.Tests.csproj
+++ b/tests/RPGTableHelper.DataLayer.Tests/RPGTableHelper.DataLayer.Tests.csproj
@@ -40,6 +40,10 @@
 
     <ProjectReference
       Include="..\..\libraries\RPGTableHelper.DataLayer\RPGTableHelper.DataLayer.csproj" />
+    <ProjectReference
+      Include="..\..\libraries\RPGTableHelper.DataLayer.OpenAI\RPGTableHelper.DataLayer.OpenAI.csproj" />
+    <ProjectReference
+      Include="..\..\libraries\RPGTableHelper.DataLayer.OpenAI.Contracts\RPGTableHelper.DataLayer.OpenAI.Contracts.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Use OpenAIClient with optional base URL; add ImageModel option
- Inline generation in AiGenerateImageQueryHandler (base64 + URL fallback)
- Register OpenAIOptions always; drop Azure image client DI
- Add unit test for missing API key path

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable OpenAI API URL and image generation model selection.
  * Image generation now supports direct image bytes retrieval with URL download fallback.

* **Bug Fixes**
  * Improved configuration validation and fallback logic when optional settings are missing.

* **Tests**
  * Added unit tests for image generation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->